### PR TITLE
Add CLI flag to allow not showing the preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,36 @@ The application supports the generation of hand drawn diagrams directly via comm
 
 ```bash
 Usage of diagram:
+  -font string
+    	path to font file (default "${GOPATH}/src/github.com/esimov/diagram/font/gloriahallelujah.ttf")
   -in string
     	Source
   -out string
     	Destination
+  -preview
+    	Show the preview window (default true)
 ```
+
+#### CLI Examples
+
+Read input from `sample.txt` and write image to `sample.png` showing a preview window with the hand drawn diagram
+
+```bash
+diagram -in sample.txt -out sample.png
+```
+
+Read input from `sample.txt` and write image to `sample.png`, and exit immediately without showing a preview window
+
+```bash
+diagram -in sample.txt -out sample.png -preview=false
+```
+
+Generate diagram as above but use a font at a different location
+
+```bash
+diagram -in sample.txt -out sample.png -preview=false -font /path/to/my/font/MyHandwriting.ttf
+```
+
 
 
 ### Key bindings

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ var (
 	source      = flag.String("in", "", "Source")
 	destination = flag.String("out", "", "Destination")
 	fontpath    = flag.String("font", defaultFontFile, "path to font file")
+	preview     = flag.Bool("preview", true, "Show the preview window")
 )
 
 func main() {
@@ -32,7 +33,7 @@ func main() {
 		err := canvas.DrawDiagram(input, *destination, *fontpath)
 		if err != nil {
 			log.Fatal("Error on converting the ascii art to hand drawn diagrams!")
-		} else {
+		} else if *preview {
 			image, _ := imview.LoadImage(*destination)
 			view := imview.ImageToRGBA(image)
 			imview.Show(view)


### PR DESCRIPTION
When running in CLI mode, it can be useful to just generate the image file without showing the preview window, especially if running from a script.

This PR just adds a CLI flag, which defaults to the current behaviour of showing the image preview window.

Sample usage:
`diagram -in sample.txt -out sample.png -preview=false`
